### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note: At the moment there is no interoperability between WebSocket and ZeroMQ im
 * https://github.com/bitfinexcom/grenache-nodejs-ws : WebSocket based Grape microservices
 
 ##### Ruby Clients
-* https://github.com/bitfinexcom/grenache-ruby-ws : ZeroMQ based Grape microservices
+* https://github.com/bitfinexcom/grenache-ruby-ws : WebSocket based Grape microservices
 
 
 ### Background


### PR DESCRIPTION
minor typo:    grenache-ruby-ws is WebSocket, not ZeroMQ